### PR TITLE
Dashboard

### DIFF
--- a/src/app/api/dashboard/latest-flashcards-created/route.ts
+++ b/src/app/api/dashboard/latest-flashcards-created/route.ts
@@ -1,0 +1,27 @@
+import { rateLimitter } from "@/middleware/rate-limit";
+import { NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+
+export async function getLastestFlashcardsCreated() {
+    try {
+        const user = await currentUser();
+        const userId = user?.id;
+
+        const response = await fetch(`http://localhost:4444/api/dashboard/latestFlashcards/${userId}`);
+        if (!response.ok) {
+            throw new Error("Error al realizar la peticion");
+        }
+        const latestFlashcards = await response.json();
+        return NextResponse.json(latestFlashcards.data);
+
+
+    } catch (error) {
+        console.error(error);
+        return NextResponse.json(
+            { error: "Error al solicitar las últimas tarjetas creadas" },
+            { status: 500 }
+        );
+    }
+}
+
+export const GET = rateLimitter({ fn: getLastestFlashcardsCreated });   

--- a/src/app/dashboard/components/Dashboard.tsx
+++ b/src/app/dashboard/components/Dashboard.tsx
@@ -9,8 +9,9 @@ import { useUserSync } from "../hooks/user-sync/useUserSync";
 import { useDashboardStats } from "../hooks/dashboard-stats/useDashboardStats";
 
 const Dashboard: React.FC = () => {
-  const { countedFlashcards } = useDashboardStats();
-  const { countedData, isLoading } = countedFlashcards;
+  const { dashboardStats } = useDashboardStats();
+  const { countedFlashcardsData, latestFlashcardsData, isLoading } =
+    dashboardStats;
 
   useUserSync();
 
@@ -25,10 +26,10 @@ const Dashboard: React.FC = () => {
     },
     {
       title: "Tema con Más Tarjetas",
-      value: countedData?.[0]?.theme ?? "Sin datos",
+      value: countedFlashcardsData?.[0]?.theme ?? "Sin datos",
       icon: <Trophy className="text-blue-400" />,
-      change: countedData?.[0]?.count
-        ? `+${countedData[0].count} tarjetas`
+      change: countedFlashcardsData?.[0]?.count
+        ? `+${countedFlashcardsData[0].count} tarjetas`
         : "Sin datos",
       chartData: [30, 35, 42, 48, 52, 58, 65],
     },
@@ -67,7 +68,7 @@ const Dashboard: React.FC = () => {
             <CardTitle>Últimas Tarjetas Creadas</CardTitle>
           </CardHeader>
           <CardContent>
-            <RecentCards />
+            <RecentCards cards={latestFlashcardsData} />
           </CardContent>
         </Card>
       </div>

--- a/src/app/dashboard/components/Dashboard.tsx
+++ b/src/app/dashboard/components/Dashboard.tsx
@@ -1,12 +1,12 @@
 "use client";
 import React from "react";
 import { BookOpen, Trophy } from "lucide-react";
-import { StatCard } from "@/app/dashboard/components/dashboard/StatCard";
 import { RecentCards } from "@/app/dashboard/components/dashboard/RecentCards";
 import { TopicDistributionChart } from "@/app/dashboard/components/dashboard/TopicDistributionChart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useUserSync } from "../hooks/user-sync/useUserSync";
 import { useDashboardStats } from "../hooks/dashboard-stats/useDashboardStats";
+import { Stats } from "./dashboard/Stats";
 
 const Dashboard: React.FC = () => {
   const { dashboardStats } = useDashboardStats();
@@ -34,25 +34,16 @@ const Dashboard: React.FC = () => {
       chartData: [30, 35, 42, 48, 52, 58, 65],
     },
   ];
-
-  if (isLoading) {
-    return <div className="text-white">Cargando estadísticas...</div>;
-  }
-
   return (
     <section className="flex flex-col w-full md:justify-center items-center p-10">
       {/* Encabezado */}
       <div className="flex flex-col justify-center items-center mb-8">
         <h1 className="text-2xl text-center font-bold text-white">
-          Panel de FlashcardsIA
+          Bienvenido a tu Espacio de MemoryNinja 🥷🏻
         </h1>
       </div>
       {/* Estadísticas */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 w-full max-w-full overflow-x-hidden md:max-w-7xl ">
-        {stats.map((stat, index) => (
-          <StatCard key={index} {...stat} />
-        ))}
-      </div>
+      <Stats stats={stats} isLoading={isLoading} />
       {/* Gráficos y tabla */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 w-full max-w-full overflow-x-hidden md:max-w-7xl">
         <Card className="lg:col-span-2">
@@ -68,7 +59,7 @@ const Dashboard: React.FC = () => {
             <CardTitle>Últimas Tarjetas Creadas</CardTitle>
           </CardHeader>
           <CardContent>
-            <RecentCards cards={latestFlashcardsData} />
+            <RecentCards cards={latestFlashcardsData} loading={isLoading} />
           </CardContent>
         </Card>
       </div>

--- a/src/app/dashboard/components/Dashboard.tsx
+++ b/src/app/dashboard/components/Dashboard.tsx
@@ -9,8 +9,8 @@ import { useUserSync } from "../hooks/user-sync/useUserSync";
 import { useDashboardStats } from "../hooks/dashboard-stats/useDashboardStats";
 
 const Dashboard: React.FC = () => {
-  const { data, isLoading } = useDashboardStats();
-  console.log("Dashboard Stats Data:", data);
+  const { countedFlashcards } = useDashboardStats();
+  const { countedData, isLoading } = countedFlashcards;
 
   useUserSync();
 
@@ -25,9 +25,11 @@ const Dashboard: React.FC = () => {
     },
     {
       title: "Tema con Más Tarjetas",
-      value: data?.[0]?.theme ?? "Sin datos",
+      value: countedData?.[0]?.theme ?? "Sin datos",
       icon: <Trophy className="text-blue-400" />,
-      change: data?.[0]?.count ? `+${data[0].count} tarjetas` : "Sin datos",
+      change: countedData?.[0]?.count
+        ? `+${countedData[0].count} tarjetas`
+        : "Sin datos",
       chartData: [30, 35, 42, 48, 52, 58, 65],
     },
   ];

--- a/src/app/dashboard/components/dashboard/RecentCards.tsx
+++ b/src/app/dashboard/components/dashboard/RecentCards.tsx
@@ -4,58 +4,53 @@ import { BookOpen, Clock, Tag } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-export const RecentCards: React.FC = () => {
+interface Card {
+  question: string;
+  theme: string;
+  createdAt: string;
+}
+
+interface RecentCardsProps {
+  cards?: Card[];
+}
+
+export const RecentCards: React.FC<RecentCardsProps> = ({ cards }) => {
   // Mock de datos
-  const cards = [
+  const mocks = [
     {
       question: "¿Qué es una función en matemáticas?",
-      topic: "Matemáticas",
+      theme: "Matemáticas",
       createdAt: "Hoy, 14:30",
-      icon: (
-        <div className="bg-blue-900/30 p-2 rounded-lg">
-          <BookOpen size={16} className="text-blue-400" />
-        </div>
-      ),
     },
     {
       question: 'What is the past tense of "run"?',
-      topic: "Inglés",
+      theme: "Inglés",
       createdAt: "Hoy, 12:15",
-      icon: (
-        <div className="bg-blue-900/30 p-2 rounded-lg">
-          <BookOpen size={16} className="text-blue-400" />
-        </div>
-      ),
     },
     {
       question: "¿Qué es un componente en React?",
-      topic: "React",
+      theme: "React",
       createdAt: "Ayer, 18:45",
-      icon: (
-        <div className="bg-blue-900/30 p-2 rounded-lg">
-          <BookOpen size={16} className="text-blue-400" />
-        </div>
-      ),
     },
     {
       question: "¿Cuándo ocurrió la Revolución Francesa?",
-      topic: "Historia",
+      theme: "Historia",
       createdAt: "Hace 2 días",
-      icon: (
-        <div className="bg-blue-900/30 p-2 rounded-lg">
-          <BookOpen size={16} className="text-blue-400" />
-        </div>
-      ),
     },
   ];
+
+  const cardsToShow = cards || mocks;
+
   return (
     <div className="space-y-4">
-      {cards.map((card, index) => (
+      {cardsToShow.map((card, index) => (
         <div
           key={index}
           className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-700 transition-colors"
         >
-          {card.icon}
+          <div className="bg-blue-900/30 p-2 rounded-lg">
+            <BookOpen size={16} className="text-blue-400" />
+          </div>
           <div className="flex-1 min-w-0">
             <h4 className="text-sm font-medium text-white truncate">
               {card.question}
@@ -63,7 +58,7 @@ export const RecentCards: React.FC = () => {
             <div className="flex items-center gap-2 text-xs text-gray-400 mt-1">
               <span className="flex items-center gap-1">
                 <Tag size={12} />
-                {card.topic}
+                {card.theme}
               </span>
               <span className="flex items-center gap-1">
                 <Clock size={12} />

--- a/src/app/dashboard/components/dashboard/RecentCards.tsx
+++ b/src/app/dashboard/components/dashboard/RecentCards.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { BookOpen, Clock, Tag } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { SkeletonCard } from "@/components/fallbacks/SkeletonCard";
 
 interface Card {
   question: string;
@@ -12,38 +13,19 @@ interface Card {
 
 interface RecentCardsProps {
   cards?: Card[];
+  loading?: boolean;
 }
 
-export const RecentCards: React.FC<RecentCardsProps> = ({ cards }) => {
-  // Mock de datos
-  const mocks = [
-    {
-      question: "¿Qué es una función en matemáticas?",
-      theme: "Matemáticas",
-      createdAt: "Hoy, 14:30",
-    },
-    {
-      question: 'What is the past tense of "run"?',
-      theme: "Inglés",
-      createdAt: "Hoy, 12:15",
-    },
-    {
-      question: "¿Qué es un componente en React?",
-      theme: "React",
-      createdAt: "Ayer, 18:45",
-    },
-    {
-      question: "¿Cuándo ocurrió la Revolución Francesa?",
-      theme: "Historia",
-      createdAt: "Hace 2 días",
-    },
-  ];
+export const RecentCards: React.FC<RecentCardsProps> = ({ cards, loading }) => {
+  const cardsToShow = cards;
 
-  const cardsToShow = cards || mocks;
+  if (loading) {
+    return <SkeletonCard />;
+  }
 
   return (
     <div className="space-y-4">
-      {cardsToShow.map((card, index) => (
+      {cardsToShow?.map((card, index) => (
         <div
           key={index}
           className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-700 transition-colors"

--- a/src/app/dashboard/components/dashboard/Stats.tsx
+++ b/src/app/dashboard/components/dashboard/Stats.tsx
@@ -1,0 +1,33 @@
+import { StatCard } from "./StatCard";
+import { SkeletonCard } from "@/components/fallbacks/SkeletonCard";
+
+interface Stats {
+  title: string;
+  value: string;
+  icon: React.JSX.Element;
+  change: string;
+  chartData: number[];
+}
+
+interface StatsProps {
+  stats: Stats[];
+  isLoading?: boolean;
+}
+
+export const Stats = ({ stats, isLoading }: StatsProps) => {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 w-full max-w-full overflow-x-hiddenmd:max-w-7xl ">
+        <SkeletonCard />;
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 w-full max-w-full overflow-x-hidden md:max-w-7xl ">
+      {stats.map((stat, index) => (
+        <StatCard key={index} {...stat} />
+      ))}
+    </div>
+  );
+};

--- a/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
+++ b/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
@@ -1,20 +1,40 @@
-
 import { getCountFlashcardsByTheme } from "@/utils/services/functions/api/dashboard/getCountFlashcardByTheme"
-import { useQuery } from "@tanstack/react-query"
+import { getLatestFlashcardsCreated } from "@/utils/services/functions/api/dashboard/getLastestFlashcardsCreated"
+import { useQueries } from "@tanstack/react-query"
 
 
 export const useDashboardStats = () => {
 
-    const { data, isLoading } = useQuery({
-        queryKey: ["countFlashcards"],
-        queryFn: async () => await getCountFlashcardsByTheme()
+    const queries = useQueries({
+        queries: [
+            {
+                queryKey: ["countFlashcards"],
+                queryFn: async () => await getCountFlashcardsByTheme()
+            },
+            {
+                queryKey: ["latestFlashcards"],
+                queryFn: async () => await getLatestFlashcardsCreated()
+            }
+        ]
     })
 
-    const countedFlashcards = {
-        countedData: data,
-        isLoading: isLoading
+    const [countedFlashcards, latestFlashcards] = queries
+
+    //Loading states 
+    const isLoading = queries.some(query => query.isLoading)
+
+    //Error validation
+    const hasErrors = queries.some(query => query.error)
+
+    //Data export
+    const dashboardStats = {
+        countedFlashcardsData: countedFlashcards.data,
+        latestFlashcardsData: latestFlashcards.data,
+        isLoading,
+        hasErrors,
+        errors: queries.map(query => query.error)
     }
 
 
-    return { countedFlashcards }
+    return { dashboardStats }
 }

--- a/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
+++ b/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
@@ -10,6 +10,11 @@ export const useDashboardStats = () => {
         queryFn: async () => await getCountFlashcardsByTheme()
     })
 
+    const countedFlashcards = {
+        countedData: data,
+        isLoading: isLoading
+    }
 
-    return { data, isLoading }
+
+    return { countedFlashcards }
 }

--- a/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
+++ b/src/app/dashboard/hooks/dashboard-stats/useDashboardStats.ts
@@ -5,15 +5,29 @@ import { useQueries } from "@tanstack/react-query"
 
 export const useDashboardStats = () => {
 
+    const commonQueryOptions = {
+        refetchInterval: 60000, // 30 segundos
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: true,
+        refetchIntervalInBackground: false,
+        staleTime: 60000, // 10 segundos
+        gcTime: 300000, // 5 minutos
+        retry: 3,
+        retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000)
+    }
+
+
     const queries = useQueries({
         queries: [
             {
                 queryKey: ["countFlashcards"],
-                queryFn: async () => await getCountFlashcardsByTheme()
+                queryFn: async () => await getCountFlashcardsByTheme(),
+                ...commonQueryOptions
             },
             {
                 queryKey: ["latestFlashcards"],
-                queryFn: async () => await getLatestFlashcardsCreated()
+                queryFn: async () => await getLatestFlashcardsCreated(),
+                ...commonQueryOptions
             }
         ]
     })

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,9 +3,10 @@ import SubscriptionFallback from "@/components/fallbacks/subscription";
 import { Protect } from "@clerk/nextjs";
 import Dashboard from "./components/Dashboard";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
 
 export default function DashboardPage() {
-  const dashboardClient = new QueryClient();
+  const [dashboardClient] = useState(() => new QueryClient());
 
   return (
     <Protect plan={"pro_user"} fallback={<SubscriptionFallback />}>

--- a/src/components/fallbacks/SkeletonCard.tsx
+++ b/src/components/fallbacks/SkeletonCard.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SkeletonCard() {
+  return (
+    <div className="flex flex-col space-y-3">
+      <Skeleton className="h-[125px] w-[250px] rounded-xl" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[250px]" />
+        <Skeleton className="h-4 w-[200px]" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils/services/functions/helpers/cnFunction"
+import { cn } from "@/lib/utils"
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/src/utils/services/functions/api/dashboard/getLastestFlashcardsCreated.ts
+++ b/src/utils/services/functions/api/dashboard/getLastestFlashcardsCreated.ts
@@ -1,0 +1,24 @@
+export const getLatestFlashcardsCreated = async () => {
+
+    const API_ENDPOINT = process.env.NEXT_PUBLIC_CLIENT_GET_LATEST_FLASHCARDS;
+
+    if (!API_ENDPOINT) {
+        throw new Error("CLIENT_GET_LATEST_FLASHCARDS no está configurado");
+    }
+
+    try {
+        const response = await fetch(API_ENDPOINT);
+
+        if (!response.ok) {
+            throw new Error("Error al recibir datos");
+        }
+
+        const data = await response.json();
+        return data;
+
+    } catch (error) {
+        if (error instanceof Error) {
+            throw new Error(error.message);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request: Mejoras del Dashboard - Estados de Carga con Skeleton y Reorganización de Componentes

## 📋 Resumen
Este PR introduce mejoras significativas en la funcionalidad del dashboard, incluyendo estados de carga apropiados, fallbacks con skeleton y mejor organización de componentes para mejorar la experiencia del usuario.

## 🚀 Cambios Realizados

### ✨ Nuevas Funcionalidades
- **Componentes de Carga Skeleton Añadidos**: Implementado componente `SkeletonCard` para mejores estados de carga
- **Reorganización de Componentes**: Reestructuración de componentes del dashboard para mejor mantenibilidad
- **Estados de Carga Mejorados**: Mejor manejo de carga en las estadísticas del dashboard

### 🔧 Mejoras Técnicas

#### Componentes del Dashboard
- **`Dashboard.tsx` Reorganizado**:
  - Extraído el renderizado de estadísticas a un componente separado `Stats`
  - Actualizado mensaje de bienvenida a "Bienvenido a tu Espacio de MemoryNinja 🥷🏻"
  - Mejorado el manejo de estados de carga para tarjetas recientes

- **`RecentCards.tsx` Mejorado**:
  - Añadida prop `loading` para manejo apropiado de estados de carga
  - Integrado skeleton loading cuando se están obteniendo datos
  - Mejoradas las interfaces de TypeScript para mejor seguridad de tipos

- **Nuevo Componente `Stats.tsx`**:
  - Extraída la lógica de renderizado de estadísticas del Dashboard principal
  - Integrado skeleton loading para tarjetas de estadísticas
  - Mejor separación de responsabilidades

#### API y Obtención de Datos
- **Hook `useDashboardStats` Mejorado**:
  - Migrado de `useQuery` a `useQueries` para mejor obtención paralela de datos
  - Añadida configuración comprensiva de queries con:
    - Intervalo de refetch de 60 segundos
    - Lógica de reintento con backoff exponencial
    - Gestión apropiada de caché (staleTime: 60s, gcTime: 5min)
    - Refetch en segundo plano deshabilitado para mejor rendimiento

- **Nuevo Endpoint de API**: 
  - Añadido `/api/dashboard/latest-flashcards-created/route.ts`
  - Integrado middleware de limitación de velocidad
  - Manejo apropiado de errores y autenticación de usuario

#### Componentes de UI
- **Componente `SkeletonCard` Añadido**:
  - Componente de carga skeleton reutilizable
  - Experiencia de carga consistente a través de la aplicación

- **`skeleton.tsx` Actualizado**:
  - Corregida ruta de importación para función utilitaria `cn`
  - Mejor integración de utilidades

### 🛠️ Mejoras en Calidad de Código
- **Mejor Manejo de Errores**: Gestión de errores mejorada en estadísticas del dashboard
- **Mejoras en TypeScript**: Añadidas interfaces apropiadas y definiciones de tipos
- **Optimizaciones de Rendimiento**: 
  - Implementadas estrategias apropiadas de caché de queries
  - Añadidos controles de refetch en segundo plano
  - Optimizados ciclos de re-renderizado

## 🔄 Notas de Migración
- El dashboard ahora usa `useQueries` en lugar de llamadas individuales `useQuery`
- Los estados de carga ahora se manejan apropiadamente con componentes skeleton
- La estructura de componentes ha sido reorganizada para mejor mantenibilidad

## 🧪 Consideraciones de Pruebas
- Verificar que los estados de carga skeleton se muestren correctamente
- Probar dashboard con conexiones de red lentas
- Asegurar que todos los endpoints de API respondan correctamente con limitación de velocidad

## 📊 Impacto en Rendimiento
- **Mejorado**: Obtención paralela de datos con `useQueries`
- **Optimizado**: Mejor gestión de caché y estrategias de refetch
- **Mejorado**: Experiencia de usuario con estados de carga apropiados

## 🎯 Próximos Pasos
- [ ] Añadir pruebas unitarias para nuevos componentes
- [ ] Implementar error boundary para dashboard
- [ ] Añadir seguimiento de analytics para interacciones del dashboard
- [ ] Considerar añadir estados de carga más granulares

---

**Commits incluidos:**
- `2e2963d`: Añadido fallback skeleton y reorganizados componentes
- `005a4e9`: Modificado a useQueries + endpoint de latestFlashcards  
- `266c049`: Añadido endpoint del servidor para últimas flashcards
- `512e4be`: Corrigiendo bugs de countedFlashcard+